### PR TITLE
Modify shelf Q values on Fiio USB devices by a factor of √2

### DIFF
--- a/devicePEQ/fiioUsbHidHandler.js
+++ b/devicePEQ/fiioUsbHidHandler.js
@@ -354,7 +354,8 @@ function handlePeqParams(data, device, filters) {
   const frequency = combineBytes(data[9], data[10]);
   const filterType = convertToFilterType(data[13]);
   let qFactor = ((combineBytes(data[11], data[12])) / 100 || 1);
-  if (filterType == "LSQ" || filterType == "HSQ") qFactor /= Math.SQRT2; // Divide by √2 due to bug of shelf filters
+  // Divide by √2 due to bug of shelf filters, then round to 2 decimal places
+  if (filterType == "LSQ" || filterType == "HSQ") qFactor = Math.round((qFactor / Math.SQRT2) * 100)/100;
 
   console.log(`Filter ${filter}: Gain=${gain}, Frequency=${frequency}, Q=${qFactor}, Type=${filterType}`);
 

--- a/devicePEQ/fiioUsbHidHandler.js
+++ b/devicePEQ/fiioUsbHidHandler.js
@@ -198,6 +198,7 @@ function getFiioReportId(deviceDetails) {
 async function setPeqParams(device, filterIndex, fc, gain, q, filterType, reportId) {
   const [frequencyLow, frequencyHigh] = splitUnsignedValue(fc);
   const [gainLow, gainHigh] = fiioGainBytesFromValue(gain);
+  if (filterType == 1 || filterType == 2) q *= Math.SQRT2; // Multiply by √2 due to bug with shelf filters
   const qFactorValue = Math.round(q * 100);
   const [qFactorLow, qFactorHigh] = splitUnsignedValue(qFactorValue);
 
@@ -351,8 +352,9 @@ function handlePeqParams(data, device, filters) {
   const filter = data[6];
   const gain = handleGain(data[7], data[8]);
   const frequency = combineBytes(data[9], data[10]);
-  const qFactor = (combineBytes(data[11], data[12])) / 100 || 1;
   const filterType = convertToFilterType(data[13]);
+  let qFactor = ((combineBytes(data[11], data[12])) / 100 || 1);
+  if (filterType == "LSQ" || filterType == "HSQ") qFactor /= Math.SQRT2; // Divide by √2 due to bug of shelf filters
 
   console.log(`Filter ${filter}: Gain=${gain}, Frequency=${frequency}, Q=${qFactor}, Type=${filterType}`);
 


### PR DESCRIPTION
This fixes a bug in Fiio devices as [described here](https://www.audiosciencereview.com/forum/index.php?threads/fiio-ka15-portable-dac-headphone-amp-review.62928/page-3#post-2377012).

I haven't modified the code for serial Fiio devices, as I don't have one to test if the bug is present there.
